### PR TITLE
Added list to wait future

### DIFF
--- a/topic_service_action_rclpy_example/topic_service_action_rclpy_example/arithmetic/operator.py
+++ b/topic_service_action_rclpy_example/topic_service_action_rclpy_example/arithmetic/operator.py
@@ -45,16 +45,19 @@ def main(args=None):
 
     operator = Operator()
 
-    while rclpy.ok():
-        rclpy.spin_once(operator)
-        incomplete_futures = []
-        for future in operator.client_futures:
-            if future.done():
-                response = future.result()
-                operator.get_logger().info('Result: {}'.format(response.arithmetic_result))
-            else:
-                incomplete_futures.append(future)
-        operator.client_futures = incomplete_futures
+    try:
+        while rclpy.ok():
+            rclpy.spin_once(operator)
+            incomplete_futures = []
+            for future in operator.client_futures:
+                if future.done():
+                    response = future.result()
+                    operator.get_logger().info('Result: {}'.format(response.arithmetic_result))
+                else:
+                    incomplete_futures.append(future)
+            operator.client_futures = incomplete_futures
+    except KeyboardInterrupt:
+        operator.get_logger().info('Keyboard Interrupt (SIGINT)')
 
     operator.destroy_node()
     rclpy.shutdown()


### PR DESCRIPTION
서비스 클라이언트 예제인 operator 에서 response 값이 두번씩 찍히는 버그가 있었습니다.

이는 타이머 콜백함수에서 서비스 클라이언트가 비동기 방식으로 request를 요청한 후 그 결괏값이 넘어 올 때, 공유 자원인 future 변수의 소유권을 돌려주는 시간차 때문에 발생하는 것으로 인한 결과로 보입니다.
(send_request 콜백함수 내부에 로그를 찍어보시면 좀더 직관적으로 확인할 수 있습니다.)

이를 해결하기 위해 send_request 와 try 제어문에서 사용하던 future를 list 버퍼에 미리 복사하여 공유자원을 만들지 않게 하였고, 그 결과 response 값이 하나씩 찍히는 것을 확인할수 있어 해당 문제는 해결할 수 있었습니다.

하지만 해당 코드는 요청 순서가 무시될 수 있는 결과를 불러 올 수 있어 신뢰성있는 코드라고 하기엔 어렵습니다.
이를 해결하기 위해 call_async() 가 아닌 call_sync() 함수는 없는지 확인해 보았는데, 이는 데드락이 일어나기 쉽기 때문에 추천하지 않는다고 합니다.
https://index.ros.org/doc/ros2/Tutorials/Sync-Vs-Async/#synchronous-calls

[ROS 2 demos 리포지토리의 demo_nodes_cpp/add_two_ints_client_async](https://github.com/ros2/demos/blob/master/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp)를 확인해 보시면 async_send_request 함수 인자에 콜백함수 참조할 수 있어 공유자원에 대한 처리를 신경쓰지 않아도 문제없도록 api가 만들어져 있습니다. [rclpy도 example에 예제](https://github.com/ros2/examples/blob/master/rclpy/services/minimal_client/examples_rclpy_minimal_client/client_async_callback.py)가 있기는 한데 rclcpp 예제에 비하면 산만한 느낌입니다.

서비스는 동기식 양방향 메시지 송수신 방식인데 비동기 프로그래밍으로 CPU 효율을 높이려 하다보니 이러한 복잡한 일이 발생하는게 아닌가 싶습니다.

후사 기대하겠습니다 :)

참조 : https://cafe.naver.com/openrt/24637